### PR TITLE
Make sure we show we errored out while activating BE

### DIFF
--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -1394,7 +1394,7 @@ libze_activate(libze_handle *lzeh, libze_activate_options *options) {
         goto err;
     }
 
-    if (mid_activate(lzeh, options, be_zh) != LIBZE_ERROR_SUCCESS) {
+    if ((ret = mid_activate(lzeh, options, be_zh)) != LIBZE_ERROR_SUCCESS) {
         goto err;
     }
 


### PR DESCRIPTION
This commit introduces changes to update the value of ret as by default that is set to SUCCESS, so in case this errors out - activation of a BE would have failed in reality but no error would have raised. It's hard to reproduce so it's possible there might be some other issues going on as well but this should at least improve the situation.