### PR TITLE
Fix for zectl snapshot core dump

### DIFF
--- a/include/libze_plugin/libze_plugin_grub.h
+++ b/include/libze_plugin/libze_plugin_grub.h
@@ -27,6 +27,9 @@ libze_error
 libze_plugin_grub_post_rename(libze_handle *lzeh, char const be_name_old[LIBZE_MAX_PATH_LEN],
                                      char const be_name_new[LIBZE_MAX_PATH_LEN]);
 
+libze_error
+libze_plugin_grub_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_data);
+
 libze_plugin_fn_export const exported_plugin = {
         .plugin_init = libze_plugin_grub_init,
         .plugin_pre_activate = libze_plugin_grub_pre_activate,
@@ -34,6 +37,7 @@ libze_plugin_fn_export const exported_plugin = {
         .plugin_post_activate = libze_plugin_grub_post_activate,
         .plugin_post_destroy = libze_plugin_grub_post_destroy,
         .plugin_post_create = libze_plugin_grub_post_create,
-        .plugin_post_rename = libze_plugin_grub_post_rename};
+        .plugin_post_rename = libze_plugin_grub_post_rename,
+        .plugin_pre_snapshot = libze_plugin_grub_pre_snapshot};
 
 #endif //ZECTL_LIBZE_PLUGIN_GRUB_H

--- a/lib/libze_plugin/libze_plugin_grub.c
+++ b/lib/libze_plugin/libze_plugin_grub.c
@@ -158,3 +158,15 @@ libze_plugin_grub_post_rename(libze_handle *lzeh, char const be_name_old[LIBZE_M
                               char const be_name_new[LIBZE_MAX_PATH_LEN]) {
     return update_grub();
 }
+
+/**
+ * @brief Pre snapshot hook
+ *
+ * @param[in,out] lzeh   libze handle
+ * @param[in] snap_data  Snapshot related data
+ * @return @p LIBZE_ERROR_SUCCESS on success
+ */
+libze_error
+libze_plugin_grub_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_data) {
+    return LIBZE_ERROR_SUCCESS;
+}


### PR DESCRIPTION
"zectl snapshot" gets core dump due to missing ```plugin_pre_snapshot()```
hook for grub plugin. Added hook ```libze_plugin_grub_pre_snapshot()``` to
fix the crash during snapshot creation.

Signed-off-by: Ameer Hamza <ahamza@ixsystems.com>