### PR TITLE
NAS-124092 / 24.04 / Fix recursive zectl_create of existing DS hierarchy

### DIFF
--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -1886,8 +1886,8 @@ err:
 libze_error
 libze_create(libze_handle *lzeh, libze_create_options *options) {
     libze_error ret = LIBZE_ERROR_SUCCESS;
-    create_data cdata;
-    create_data boot_pool_cdata;
+    create_data cdata = (create_data){ .recursive = options->recursive };
+    create_data boot_pool_cdata = { 0 };
     char be_created[ZFS_MAX_DATASET_NAME_LEN] = "";
 
     /* Populate cdata from existing dataset or snap */


### PR DESCRIPTION
If boot environment contains child datasets, we need to pass along the recursive argument so that we take a recursive snapshot of children, otherwise zectl_clone() will fail due to missing snapshot.