### PR TITLE
[stable/electriceel] Update libzfs version

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,9 +8,9 @@ Build-Depends:
  libbsd-dev,
  libnvpair3,
  libuutil3,
- libzfs5,
- libzfs5-devel,
- libzpool5,
+ libzfs6,
+ libzfs6-devel,
+ libzpool6,
  pkgconf
 Standards-Version: 4.5.0
 Homepage: https://github.com/johnramsden/zectl


### PR DESCRIPTION
https://github.com/openzfs/zfs/commit/277a124 updated libzfs version prior to zfs-2.3 release.
Jira Ticket: https://ixsystems.atlassian.net/browse/NAS-131707.
Scale Build: http://jenkins.eng.ixsystems.net:8080/job/electriceel/job/custom/34/
API Test Run: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1278/